### PR TITLE
This attempts to fix some memory copies in the save_params function.

### DIFF
--- a/pntr_app_sfx.h
+++ b/pntr_app_sfx.h
@@ -654,11 +654,11 @@ bool pntr_app_sfx_save_params(SfxParams* params, const char* fileName) {
   short int version = 200;
   short int len = 96;
   PNTR_MEMCPY(&fileData, signature, 4);
-  PNTR_MEMCPY(fileData + 4, &version, 2);
-  PNTR_MEMCPY(fileData + 6, &len, 2);
-  PNTR_MEMCPY(fileData + 8, &params, 96);
+  PNTR_MEMCPY(fileData + 4, &version, sizeof(short int));
+  PNTR_MEMCPY(fileData + 4 + sizeof(short int), &len, sizeof(short int));
+  PNTR_MEMCPY(fileData + 4 + sizeof(short int) + sizeof(short int), &params, sizeof(SfxParams));
 
-  return pntr_save_file(fileName, &fileData, 104);
+  return pntr_save_file(fileName, &fileData, 4 + sizeof(short int) * + sizeof(short int) + sizeof(SfxParams));
 }
 
 void pntr_app_sfx_gen_pickup_coin(pntr_app* app, SfxParams* sp) {


### PR DESCRIPTION
```
pntr_app_sfx.h:659:3:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:10: warning: ‘__builtin_memcpy’ reading 96 bytes from a region of size 8 [-Wstringop-overread]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
```
